### PR TITLE
Fix SPM build by excluding internal libunrar sources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,11 @@ let package = Package(
                 "libunrar/uowners.cpp",
                 "libunrar/win32acl.cpp",
                 "libunrar/win32lnk.cpp",
-                "libunrar/win32stm.cpp"
+                "libunrar/win32stm.cpp",
+                "libunrar/blake2s_sse.cpp",
+                "libunrar/threadmisc.cpp",
+                "libunrar/uiconsole.cpp",
+                "libunrar/unpack50mt.cpp"
             ],
             publicHeadersPath: ".",
             cSettings: [


### PR DESCRIPTION
## Summary
- avoid compiling libunrar sources that are meant to be included by other files
- update `Package.swift` exclude list

## Testing
- `swift build` *(fails: unknown type name 'DWORD' in isnt.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_687623006c48832c83e507b8e2ceceb7